### PR TITLE
ヘッダーclass表記修正

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -13,7 +13,7 @@
 
         <li class='nav-item dropdown dropdown-slide'>
           <%= link_to 'マイページ', '#', class: 'nav-link', data: { bs_toggle: 'dropdown' }, aria: { haspopup: 'true', expanded: 'false' }, id: 'header-profile' do %>
-            <%= image_tag ('bread_sample.jpg', class: 'img-fluid', alt: 'Bread Sample', class: 'rounded-circle mr15', width: '40', height: '40') %>
+            <%= image_tag ('bread_sample.jpg', class: 'img-fluid rounded-circle mr15', alt: 'Bread Sample', width: '40', height: '40') %>
           <% end %>
         </li>
       </ul>


### PR DESCRIPTION
ヘッダーの文法を修正
```
<li class='nav-item dropdown dropdown-slide'>
          <%= link_to 'マイページ', '#', class: 'nav-link', data: { bs_toggle: 'dropdown' }, aria: { haspopup: 'true', expanded: 'false' }, id: 'header-profile' do %>
            <%= image_tag ('bread_sample.jpg', class: 'img-fluid', alt: 'Bread Sample', class: 'rounded-circle mr15', width: '40', height: '40') %>
↓
            <%= image_tag('bread_sample.jpg', class: 'img-fluid rounded-circle mr15', alt: 'Bread Sample', width: '40', height: '40') %>
            クラスをまとめる？ってん感じ
          <% end %>
        </li>
```