### PR TITLE
画像を円にする

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -14,7 +14,7 @@
         <li class='nav-item dropdown dropdown-slide'>
           <%= link_to root_path, class: 'nav-link', data: { toggle: 'dropdown' }, aria: { haspopup: 'true', expanded: 'false' }, id: 'header-profile' do %>
             マイページ
-            <%= image_tag('bread_sample.jpg', class: 'img-fluid rounded-circle mr15', alt: 'Bread Sample', width: '40', height: '40') %>
+            <%= image_tag('bread_sample.jpg', class: 'img-fluid rounded-circle mr-2', alt: 'Bread Sample', width: '40', height: '40', style: 'object-fit: cover; object-position: center;') %>
           <% end %>
         </li>
       </ul>


### PR DESCRIPTION
画像が正方形でなくても、CSSで画像を円形にする方法があります。border-radius プロパティを使用して、画像に適用する角丸の半径を設定します。以下のように修正してみてください：

erb
コードをコピーする
<li class='nav-item dropdown dropdown-slide'>
  <%= link_to root_path, class: 'nav-link', data: { toggle: 'dropdown' }, aria: { haspopup: 'true', expanded: 'false' }, id: 'header-profile' do %>
    <%= image_tag('bread_sample.jpg', class: 'img-fluid rounded-circle mr-2', alt: 'Bread Sample', width: '40', height: '40', style: 'object-fit: cover; object-position: center;') %>
    マイページ
  <% end %>
</li>
ここで行った主な変更は次の通りです：

image_tag に style 属性を追加しています。これにより、画像が要素の中央に配置され、適切に表示されるようになります。
rounded-circle クラスを使って画像に円形を適用しています。
画像の表示を調整するために object-fit: cover; object-position: center; をスタイルに追加しています。これにより、画像が適切にリサイズされ、中央に配置されます。